### PR TITLE
Revert "Ensure all event data returned ends with LF"

### DIFF
--- a/lib/event_source.dart
+++ b/lib/event_source.dart
@@ -172,9 +172,10 @@ class EventSource {
       _nextEventName = value;
     } else if (name == 'data') {
       if (_nextData == null) {
-        _nextData = '';
+        _nextData = value;
+      } else {
+        _nextData += '\n$value';
       }
-      _nextData += '$value\n';
     } else if (name == 'id') {
       _lastEventID = value;
     } else if (name == 'retry') {

--- a/test/event_source_test.dart
+++ b/test/event_source_test.dart
@@ -26,7 +26,7 @@ void main() {
   });
 
   test('opens and closes connection when listening on `events`', () async {
-    final data = 'example data\n';
+    final data = 'example data';
 
     _responses = [
       'retry:10000',
@@ -55,7 +55,7 @@ void main() {
     final second = events.elementAt(1);
 
     final message = await first;
-    expect(message.data, equals('example\n'));
+    expect(message.data, equals('example'));
 
     // Kill the connection
     final port = server.port;
@@ -68,6 +68,6 @@ void main() {
     });
 
     final message2 = await second;
-    expect(message2.data, equals('back\n'));
+    expect(message2.data, equals('back'));
   });
 }


### PR DESCRIPTION
Oops, I missed the end of the spec which removes the LF afterwards. The original logic was correct. Sorry for the hassle.