### PR TITLE
Reconnect after HTTP request completes

### DIFF
--- a/lib/event_source.dart
+++ b/lib/event_source.dart
@@ -1,5 +1,5 @@
 import 'dart:async' show Future, Stream, StreamController, Timer;
-import 'dart:io' show HttpClient;
+import 'dart:io' show HttpClient, HttpStatus;
 import 'dart:convert' show LineSplitter, utf8;
 
 class MessageEvent {
@@ -100,7 +100,11 @@ class EventSource {
     }
 
     final response = await request.close();
-    if (response.statusCode != 200) {
+    if (response.statusCode == HttpStatus.noContent) {
+      close();
+      return;
+    }
+    if (response.statusCode != HttpStatus.ok) {
       _reconnect();
       return;
     }

--- a/lib/event_source.dart
+++ b/lib/event_source.dart
@@ -100,15 +100,19 @@ class EventSource {
     }
 
     final response = await request.close();
+    if (response.statusCode != 200) {
+      _reconnect();
+      return;
+    }
+
     _readyState = OPEN;
 
     response
-        .handleError((_) {
-          _reconnect();
-        })
         .transform(utf8.decoder)
         .transform(LineSplitter())
-        .listen(_onMessage);
+        .listen(_onMessage, onDone: _reconnect, onError: (_) {
+      _reconnect();
+    });
   }
 
   /// Closes the connection, if any, and sets the `readyState` attribute to `CLOSED`.


### PR DESCRIPTION
Also handle reconnection for more error cases:
- Invalid UTF-8
- non-200 OK status codes.

Without this fix any connections that close normally will not be retried.

Found when an event request received a 500 failure and the event-source failed altogether.
In that case the 500 response body was parsed as a very short event stream and the event stream completed without a re-connection.

Also stop the event stream if the server returns a 204 No Content.