### PR TITLE
Force releasing old client connections

### DIFF
--- a/lib/event_source.dart
+++ b/lib/event_source.dart
@@ -148,7 +148,7 @@ class EventSource {
     }
 
     if (_readyState != CLOSED) {
-      _client.close();
+      _client.close(force: true);
       _client = null;
       _readyState = CLOSED;
     }


### PR DESCRIPTION
This is needed to ensure resources are released when reconnecting.