### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,22 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.0
+* Delay reconnecting with randomized exponential backoff. ([@mpx](https://github.com/mpx))
+* Reconnect after event stream request ends. ([@mpx](https://github.com/mpx))
+* Reconnect after protocol errors (invalid UTF-8, non-200 OK status codes). ([@mpx](https://github.com/mpx))
+* Stop event stream after 204 No Content. ([@mpx](https://github.com/mpx))
+* Ensure resources are released for old connections. ([@mpx](https://github.com/mpx))
+
 ## 1.2.2
-* Revert `data` event commit, which was a misreading of the spec. ([@mpx](https://github.com/mpx) in [#4](https://github.com/goto-bus-stop/dart-event-source/pull/4))
+* Revert `data` event commit, which was a misreading of the spec. ([@mpx](https://github.com/mpx))
 
 ## 1.2.1
-* Ensure `data` event data ends in \n per the spec. ([@mpx](https://github.com/mpx) in [#2](https://github.com/goto-bus-stop/dart-event-source/pull/3))
-* Fix event name bug in multiline data messages. ([@mpx](https://github.com/mpx) in [#2](https://github.com/goto-bus-stop/dart-event-source/pull/3))
+* Ensure `data` event data ends in \n per the spec. ([@mpx](https://github.com/mpx))
+* Fix event name bug in multiline data messages. ([@mpx](https://github.com/mpx))
 
 ## 1.2.0
-* Allow passing in a custom HttpClient factory. ([@mpx](https://github.com/mpx) in [#2](https://github.com/goto-bus-stop/dart-event-source/pull/2))
+* Allow passing in a custom HttpClient factory. ([@mpx](https://github.com/mpx))
 
 ## 1.1.0
 * Implement auto-reconnect.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  w3c_event_source: ^1.2.2
+  w3c_event_source: ^1.3.0
 ```
 
 ## Usage

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w3c_event_source
-version: 1.2.2
+version: 1.3.0
 description: W3C EventSource client implementation for Dart / Flutter,
   to communicate with server-sent event endpoints.
 author: Renée Kooi <renee@kooi.me>


### PR DESCRIPTION
I've bumped the minor number since the exponential backoff improves the behaviour significantly and changes the externally visible API.

I have a preference to drop referring to pull requests in the changelog since the details are in git. If that's ok with you, I'll update this pull request. If not, that's fine too :).

I'd like to add an "onStateChange(state)" hook to allow users to track state changes when they occur. Please let me know if you would prefer to send that through first so it can be included in the 1.3.0 release bump. Otherwise it can be left until a later release to discuss/add.