### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/event_source.dart
+++ b/lib/event_source.dart
@@ -132,6 +132,7 @@ class EventSource {
     // is only called once per connection.
     var reconnectOnce = _onceFunc(_reconnect);
     response
+        .cast<List<int>>()
         .transform(utf8.decoder)
         .transform(LineSplitter())
         .listen(_onMessage, onDone: reconnectOnce, onError: (_) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w3c_event_source
-version: 1.3.0+1
+version: 1.3.0
 description: W3C EventSource client implementation for Dart / Flutter,
   to communicate with server-sent event endpoints.
 author: Renée Kooi <renee@kooi.me>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: w3c_event_source
-version: 1.3.0
+version: 1.3.0+1
 description: W3C EventSource client implementation for Dart / Flutter,
   to communicate with server-sent event endpoints.
 author: Renée Kooi <renee@kooi.me>


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900