### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/event_source.dart
+++ b/lib/event_source.dart
@@ -131,9 +131,8 @@ class EventSource {
     // One or both of "done" and "error" events can trigger. Ensure reconnect
     // is only called once per connection.
     var reconnectOnce = _onceFunc(_reconnect);
-    response
-        .cast<List<int>>()
-        .transform(utf8.decoder)
+    uf8.decoder
+        .bind(response)
         .transform(LineSplitter())
         .listen(_onMessage, onDone: reconnectOnce, onError: (_) {
       reconnectOnce();

--- a/lib/event_source.dart
+++ b/lib/event_source.dart
@@ -131,7 +131,7 @@ class EventSource {
     // One or both of "done" and "error" events can trigger. Ensure reconnect
     // is only called once per connection.
     var reconnectOnce = _onceFunc(_reconnect);
-    uf8.decoder
+    utf8.decoder
         .bind(response)
         .transform(LineSplitter())
         .listen(_onMessage, onDone: reconnectOnce, onError: (_) {


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible chnage updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900